### PR TITLE
Add `accept_null_value` option to keep backward compatibility

### DIFF
--- a/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
+++ b/src/main/java/org/embulk/output/elasticsearch/ElasticsearchOutputPluginDelegate.java
@@ -129,6 +129,10 @@ public class ElasticsearchOutputPluginDelegate
         @Config("time_zone")
         @ConfigDefault("\"UTC\"")
         String getTimeZone();
+
+        @Config("accept_null_value")
+        @ConfigDefault("false")
+        boolean getAcceptNull();
     }
 
     public enum Mode
@@ -234,7 +238,7 @@ public class ElasticsearchOutputPluginDelegate
             Optional.fromNullable(configSource.loadConfig(FormatterIntlColumnOption.class)));
 
         return JacksonServiceRequestMapper.builder()
-                .add(new JacksonAllInObjectScope(formatter, true), new JacksonTopLevelValueLocator("record"))
+                .add(new JacksonAllInObjectScope(formatter, task.getAcceptNull()), new JacksonTopLevelValueLocator("record"))
                 .build();
     }
 

--- a/src/test/java/org/embulk/output/elasticsearch/ElasticsearchTestUtils.java
+++ b/src/test/java/org/embulk/output/elasticsearch/ElasticsearchTestUtils.java
@@ -110,7 +110,8 @@ public class ElasticsearchTestUtils
                 .set("bulk_actions", ES_BULK_ACTIONS)
                 .set("bulk_size", ES_BULK_SIZE)
                 .set("concurrent_requests", ES_CONCURRENT_REQUESTS)
-                .set("maximum_retries", 2);
+                .set("maximum_retries", 2)
+                .set("accept_null_value", true);
     }
 
     public ImmutableMap<String, Object> inputConfig()


### PR DESCRIPTION
Hi. Thanks for PR https://github.com/embulk/embulk-output-elasticsearch/pull/47
I'm a maintainer of embulk-output-elasticsearch.

As you're saying, null values will be outputed to elasticsearch as `null`, not `undefined`.
I considered about backward compatibility and created `accept_null_value` option and set `false` as a default.
